### PR TITLE
feat: add 'as' prop to Navigation Link component

### DIFF
--- a/src/lib/sections/Navigation/Content/Content.stories.tsx
+++ b/src/lib/sections/Navigation/Content/Content.stories.tsx
@@ -27,13 +27,13 @@ export const Example = { args: { children: (
   <>
     <Navigation.List>
       <Navigation.Item>
-        <Navigation.Link to="#" current="page">
+        <Navigation.Link href="#" aria-current="page">
           <Navigation.Icon name="code" />
           <Navigation.Label>Settings</Navigation.Label>
         </Navigation.Link>
       </Navigation.Item>
       <Navigation.Item>
-        <Navigation.Link to="#">
+        <Navigation.Link href="#">
           <Navigation.Icon name="user" />
           <Navigation.Label>Account</Navigation.Label>
         </Navigation.Link>
@@ -41,13 +41,13 @@ export const Example = { args: { children: (
     </Navigation.List>
     <Navigation.List>
       <Navigation.Item>
-        <Navigation.Link to="#">
+        <Navigation.Link href="#">
           <Navigation.Icon name="information" />
           <Navigation.Label>About</Navigation.Label>
         </Navigation.Link>
       </Navigation.Item>
       <Navigation.Item>
-        <Navigation.Link to="#">
+        <Navigation.Link href="#">
           <Navigation.Icon name="help" />
           <Navigation.Label>Get support</Navigation.Label>
         </Navigation.Link>

--- a/src/lib/sections/Navigation/Drawer/Drawer.stories.tsx
+++ b/src/lib/sections/Navigation/Drawer/Drawer.stories.tsx
@@ -54,13 +54,13 @@ export const Example = { args: { children: (
     <Navigation.Content>
       <Navigation.List>
         <Navigation.Item>
-          <Navigation.Link to="#" current="page">
+          <Navigation.Link href="#" aria-current="page">
             <Navigation.Icon name="code" />
             <Navigation.Label>Settings</Navigation.Label>
           </Navigation.Link>
         </Navigation.Item>
         <Navigation.Item>
-          <Navigation.Link to="#">
+          <Navigation.Link href="#">
             <Navigation.Icon name="user" />
             <Navigation.Label>Account</Navigation.Label>
           </Navigation.Link>
@@ -68,13 +68,13 @@ export const Example = { args: { children: (
       </Navigation.List>
       <Navigation.List>
         <Navigation.Item>
-          <Navigation.Link to="#">
+          <Navigation.Link href="#">
             <Navigation.Icon name="information" />
             <Navigation.Label>About</Navigation.Label>
           </Navigation.Link>
         </Navigation.Item>
         <Navigation.Item>
-          <Navigation.Link to="#">
+          <Navigation.Link href="#">
             <Navigation.Icon name="help" />
             <Navigation.Label>Get support</Navigation.Label>
           </Navigation.Link>

--- a/src/lib/sections/Navigation/Icon/Icon.stories.tsx
+++ b/src/lib/sections/Navigation/Icon/Icon.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Navigation.Icon> = {
         <Navigation.Content>
           <Navigation.List>
             <Navigation.Item>
-              <Navigation.Link to="#">
+              <Navigation.Link href="#">
                 <Navigation.Icon {...args} />
               </Navigation.Link>
             </Navigation.Item>

--- a/src/lib/sections/Navigation/Item/Item.stories.tsx
+++ b/src/lib/sections/Navigation/Item/Item.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<typeof Navigation.Item> = {
 
 export default meta;
 export const Example = { args: { children: (
-  <Navigation.Link to="#">
+  <Navigation.Link href="#">
     <Navigation.Icon name="code" />
     <Navigation.Label>Settings</Navigation.Label>
   </Navigation.Link>

--- a/src/lib/sections/Navigation/Label/Label.stories.tsx
+++ b/src/lib/sections/Navigation/Label/Label.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Navigation.Label> = {
         <Navigation.Content>
           <Navigation.List>
             <Navigation.Item>
-              <Navigation.Link to="#">
+              <Navigation.Link href="#">
                 <Navigation.Label {...args} />
               </Navigation.Link>
             </Navigation.Item>

--- a/src/lib/sections/Navigation/Link/Link.stories.tsx
+++ b/src/lib/sections/Navigation/Link/Link.stories.tsx
@@ -29,6 +29,7 @@ const meta: Meta<typeof Navigation.Link> = {
 export default meta;
 export const Example = {
   args: {
+    as: "a",
     href: "#",
     "aria-current": "page",
     children: (

--- a/src/lib/sections/Navigation/Link/Link.stories.tsx
+++ b/src/lib/sections/Navigation/Link/Link.stories.tsx
@@ -40,3 +40,14 @@ export const Example = {
     ),
   },
 };
+
+export const ButtonExample = {
+  args: {
+    as: "button",
+    children: (
+      <>
+        <Navigation.Label>Log out</Navigation.Label>
+      </>
+    ),
+  },
+};

--- a/src/lib/sections/Navigation/Link/Link.stories.tsx
+++ b/src/lib/sections/Navigation/Link/Link.stories.tsx
@@ -27,9 +27,15 @@ const meta: Meta<typeof Navigation.Link> = {
 };
 
 export default meta;
-export const Example = { args: { to: "#", current: "page", children: (
-  <>
-    <Navigation.Icon name="code" />
-    <Navigation.Label>Settings</Navigation.Label>
-  </>
-)}};
+export const Example = {
+  args: {
+    href: "#",
+    "aria-current": "page",
+    children: (
+      <>
+        <Navigation.Icon name="code" />
+        <Navigation.Label>Settings</Navigation.Label>
+      </>
+    ),
+  },
+};

--- a/src/lib/sections/Navigation/Link/Link.tsx
+++ b/src/lib/sections/Navigation/Link/Link.tsx
@@ -1,15 +1,25 @@
-import { AriaAttributes, ReactNode } from "react";
+import { ComponentProps, ElementType } from "react";
 
-export interface NavigationLinkProps {
-  children: ReactNode;
-  to: string;
-  current?: AriaAttributes["aria-current"]
+import classNames from "classnames";
+
+interface AsProp<C extends ElementType> {
+  as?: C;
 }
 
-export const Link = ({ children, current, to }: NavigationLinkProps) => {
+export interface NavigationLinkProps extends ComponentProps<typeof Link> {}
+
+export const Link = <
+  C extends ElementType = "a",
+  T extends ComponentProps<C> = ComponentProps<C>,
+>({
+  as,
+  ...props
+}: AsProp<C> & Omit<T, "as">) => {
+  const Component = as || "a";
   return (
-    <a className="p-side-navigation__link" href={to} aria-current={current}>
-      {children}
-    </a>
-  )
-}
+    <Component
+      className={classNames("p-side-navigation__link", props.className)}
+      {...props}
+    />
+  );
+};

--- a/src/lib/sections/Navigation/List/List.stories.tsx
+++ b/src/lib/sections/Navigation/List/List.stories.tsx
@@ -28,13 +28,13 @@ export default meta;
 export const Example = { args: { children: (
   <>
     <Navigation.Item>
-      <Navigation.Link to="#" current="page">
+      <Navigation.Link href="#" aria-current="page">
         <Navigation.Icon name="code" />
         <Navigation.Label>Settings</Navigation.Label>
       </Navigation.Link>
     </Navigation.Item>
     <Navigation.Item>
-      <Navigation.Link to="#">
+      <Navigation.Link href="#">
         <Navigation.Icon name="user" />
         <Navigation.Label>Account</Navigation.Label>
       </Navigation.Link>

--- a/src/lib/sections/Navigation/Navigation.scss
+++ b/src/lib/sections/Navigation/Navigation.scss
@@ -19,7 +19,8 @@
     margin-bottom: 0;
   }
 
-  &:hover, &:visited {
+  &:hover,
+  &:visited {
     color: $colors--dark-theme--text-default;
     text-decoration: none;
   }
@@ -46,4 +47,12 @@
   @media only screen and (min-width: ($breakpoint-small + 1)) {
     left: 1.5rem;
   }
+}
+
+// link button styling
+button.p-side-navigation__link {
+  background-color: transparent;
+  border: none;
+  width: 100%;
+  justify-content: flex-start;
 }

--- a/src/lib/sections/Navigation/Navigation.stories.tsx
+++ b/src/lib/sections/Navigation/Navigation.stories.tsx
@@ -73,7 +73,7 @@ const meta: Meta<typeof Navigation> = {
           <Navigation.Content>
             <Navigation.List>
               <Navigation.Item>
-                <Navigation.Link to="#" current="page">
+                <Navigation.Link href="#" aria-current="page">
                   <Navigation.Icon name="information" />
                   <Navigation.Label>Settings</Navigation.Label>
                 </Navigation.Link>
@@ -81,13 +81,13 @@ const meta: Meta<typeof Navigation> = {
             </Navigation.List>
             <Navigation.List>
               <Navigation.Item>
-                <Navigation.Link to="#">
+                <Navigation.Link href="#">
                   <Navigation.Icon name="user" />
                   <Navigation.Label>admin</Navigation.Label>
                 </Navigation.Link>
               </Navigation.Item>
               <Navigation.Item>
-                <Navigation.Link to="#">
+                <Navigation.Link as="button">
                   <Navigation.Label>Log out</Navigation.Label>
                 </Navigation.Link>
               </Navigation.Item>


### PR DESCRIPTION
## Done
- Added `as` prop to navigation link
- infer props from component passed to `as` prop
- utilize native `<a>` attributes where `as` is not provided

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Ensure that the link component renders correctly
- [ ] Ensure that the logout button also renders correctly on the Navigation story page

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
<img width="1198" alt="navigation link" src="https://github.com/canonical/maas-react-components/assets/47540149/b024473e-bfe2-4d64-9e7b-e60d16e6e040">

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
