### PR TITLE
docs: add close menu button to nav story

### DIFF
--- a/src/lib/sections/Navigation/MenuButton/MenuButton.tsx
+++ b/src/lib/sections/Navigation/MenuButton/MenuButton.tsx
@@ -12,7 +12,7 @@ export interface NavigationMenuButtonProps {
 export const MenuButton = ({ children, className, onClick }: NavigationMenuButtonProps) => {
 
   return (
-    <Button appearance="base" className={classNames("has-icon is-dark", className)} onClick={onClick}>
+    <Button appearance="base" className={classNames("p-side-navigation__button--menu has-icon is-dark", className)} onClick={onClick}>
       {children}
     </Button>
   )

--- a/src/lib/sections/Navigation/Navigation.scss
+++ b/src/lib/sections/Navigation/Navigation.scss
@@ -83,6 +83,13 @@ $side-navigation-z-index: 103;
         display: inherit;
       }
     }
+
+    .p-side-navigation__button--menu {
+      @media only screen and (min-width: ($breakpoint-x-small)){
+        display: none;
+      }
+
+    }
   }
   
   // link button styling

--- a/src/lib/sections/Navigation/Navigation.stories.tsx
+++ b/src/lib/sections/Navigation/Navigation.stories.tsx
@@ -67,6 +67,9 @@ const meta: Meta<typeof Navigation> = {
                   isCollapsed={args["isCollapsed"]}
                   setIsCollapsed={() => {}}
                 />
+                <NavigationBar.MenuButton onClick={() => {}}>
+                  Close menu
+                </NavigationBar.MenuButton>
               </Navigation.Controls>
             </Navigation.Banner>
           </Navigation.Header>


### PR DESCRIPTION
## Done
- Added a "Close menu" button to the Navigation story
- Added a class name for menu buttons
- Hid menu buttons in the main nav unless the user is on mobile

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Run storybook
- [ ] Go to main Navigation example
- [ ] Set viewport size to mobile
- [ ] Ensure the "Close menu" button is visible
- [ ] Click the button to rotate the viewport orientation (mobile landscape)
- [ ] Ensure the "Close menu" button is hidden

<!-- Steps for QA. -->

## Screenshots
![image](https://github.com/ndv99/maas-react-components/assets/35104482/5db0cd71-4240-4440-95eb-7247c5f9b876)


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
