### PR TITLE
feat: add canonical to logo name

### DIFF
--- a/src/lib/sections/Navigation/Banner/Banner.stories.tsx
+++ b/src/lib/sections/Navigation/Banner/Banner.stories.tsx
@@ -43,8 +43,9 @@ export const Example = { args: { children: (
         <path d="M156.94 149H31.88a18.88 18.88 0 0 1 .27 19.5c-.09.16-.19.31-.29.46h125.08A6 6 0 0 0 163 163v-8.06a6 6 0 0 0-6-6Z" />
       </Navigation.LogoIcon>
     </Navigation.LogoTag>
-    <Navigation.LogoName>
-      MAAS
-    </Navigation.LogoName>
+    <Navigation.LogoText>
+      <Navigation.LogoName variant="small">Canonical</Navigation.LogoName>
+      <Navigation.LogoName>MAAS</Navigation.LogoName>
+    </Navigation.LogoText>
   </Navigation.Logo>
 )}};

--- a/src/lib/sections/Navigation/Drawer/Drawer.stories.tsx
+++ b/src/lib/sections/Navigation/Drawer/Drawer.stories.tsx
@@ -42,9 +42,10 @@ export const Example = { args: { children: (
               <path d="M156.94 149H31.88a18.88 18.88 0 0 1 .27 19.5c-.09.16-.19.31-.29.46h125.08A6 6 0 0 0 163 163v-8.06a6 6 0 0 0-6-6Z" />
             </Navigation.LogoIcon>
           </Navigation.LogoTag>
-          <Navigation.LogoName>
-            MAAS
-          </Navigation.LogoName>
+          <Navigation.LogoText>
+            <Navigation.LogoName variant="small">Canonical</Navigation.LogoName>
+            <Navigation.LogoName>MAAS</Navigation.LogoName>
+          </Navigation.LogoText>
         </Navigation.Logo>
         <Navigation.Controls>
           <Navigation.CollapseToggle isCollapsed={false} setIsCollapsed={() => {}} />

--- a/src/lib/sections/Navigation/Header/Header.stories.tsx
+++ b/src/lib/sections/Navigation/Header/Header.stories.tsx
@@ -42,9 +42,10 @@ export const Example = { args: { children: (
           <path d="M156.94 149H31.88a18.88 18.88 0 0 1 .27 19.5c-.09.16-.19.31-.29.46h125.08A6 6 0 0 0 163 163v-8.06a6 6 0 0 0-6-6Z" />
         </Navigation.LogoIcon>
       </Navigation.LogoTag>
-      <Navigation.LogoName>
-        MAAS
-      </Navigation.LogoName>
+      <Navigation.LogoText>
+        <Navigation.LogoName variant="small">Canonical</Navigation.LogoName>
+        <Navigation.LogoName>MAAS</Navigation.LogoName>
+      </Navigation.LogoText>
     </Navigation.Logo>
     <Navigation.Controls>
       <Navigation.CollapseToggle isCollapsed={false} setIsCollapsed={() => {}} />

--- a/src/lib/sections/Navigation/Logo/Logo.stories.tsx
+++ b/src/lib/sections/Navigation/Logo/Logo.stories.tsx
@@ -45,8 +45,9 @@ export const Example = { args: { children: (
         <path d="M156.94 149H31.88a18.88 18.88 0 0 1 .27 19.5c-.09.16-.19.31-.29.46h125.08A6 6 0 0 0 163 163v-8.06a6 6 0 0 0-6-6Z" />
       </Navigation.LogoIcon>
     </Navigation.LogoTag>
-    <Navigation.LogoName>
-      MAAS
-    </Navigation.LogoName>
+    <Navigation.LogoText>
+      <Navigation.LogoName variant="small">Canonical</Navigation.LogoName>
+      <Navigation.LogoName>MAAS</Navigation.LogoName>
+    </Navigation.LogoText>
   </>
 )}}

--- a/src/lib/sections/Navigation/LogoName/LogoName.stories.tsx
+++ b/src/lib/sections/Navigation/LogoName/LogoName.stories.tsx
@@ -11,9 +11,9 @@ const meta: Meta<typeof Navigation.LogoName> = {
         <Navigation.Header>
           <Navigation.Banner>
             <Navigation.Logo>
-              <Navigation.LogoName>
-                {args["children"]}
-              </Navigation.LogoName>
+              <Navigation.LogoText>
+                <Navigation.LogoName {...args} />
+              </Navigation.LogoText>
             </Navigation.Logo>
           </Navigation.Banner>
         </Navigation.Header>
@@ -29,4 +29,5 @@ const meta: Meta<typeof Navigation.LogoName> = {
 };
 
 export default meta;
-export const Example = { args: { children: "MAAS" }}
+export const Example = { args: { children: "MAAS", variant: "base" }}
+export const SmallExample = { args: { children: "Canonical", variant: "small" }}

--- a/src/lib/sections/Navigation/LogoName/LogoName.tsx
+++ b/src/lib/sections/Navigation/LogoName/LogoName.tsx
@@ -1,14 +1,20 @@
 import { ReactNode } from "react";
 
+import classNames from "classnames";
+
 export interface NavigationLogoNameProps {
   children: ReactNode;
+  variant?: "base" | "small";
 }
 
-export const LogoName = ({ children }: NavigationLogoNameProps) => {
-
+export const LogoName = ({ children, variant = "base" }: NavigationLogoNameProps) => {
   return (
-    <div className="p-panel__logo-name is-fading-when-collapsed">
+    <div
+      className={classNames("p-panel__logo-name is-fading-when-collapsed", {
+        "p-panel__logo-name--small": variant === "small",
+      })}
+    >
       {children}
     </div>
-  )
-}
+  );
+};

--- a/src/lib/sections/Navigation/LogoText/LogoText.tsx
+++ b/src/lib/sections/Navigation/LogoText/LogoText.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from "react";
+
+export interface NavigationTextProps {
+  children: ReactNode;
+}
+
+export const LogoText = ({ children }: NavigationTextProps) => {
+
+  return (
+    <span className="p-panel__logo-text">
+      {children}
+    </span>
+  )
+}

--- a/src/lib/sections/Navigation/Navigation.scss
+++ b/src/lib/sections/Navigation/Navigation.scss
@@ -62,6 +62,10 @@ $side-navigation-z-index: 103;
     }
   }
 
+  .p-panel__header {
+    margin-bottom: 1rem;
+  }
+
   .p-panel__controls {
     margin-left: auto;
     padding-top: 0.65rem;

--- a/src/lib/sections/Navigation/Navigation.scss
+++ b/src/lib/sections/Navigation/Navigation.scss
@@ -93,10 +93,9 @@ $side-navigation-z-index: 103;
     }
 
     .p-side-navigation__button--menu {
-      @media only screen and (min-width: ($breakpoint-x-small)){
+      @media only screen and (min-width: ($breakpoint-x-small)) {
         display: none;
       }
-
     }
   }
 
@@ -147,8 +146,8 @@ $side-navigation-z-index: 103;
     color: $colors--dark-theme--text-default;
     display: flex;
     flex-direction: column;
+    margin-top: 0.25rem;
     @media only screen and (max-width: ($breakpoint-small)) {
-      margin-top: 1.25rem;
       margin-bottom: 0;
     }
 
@@ -157,29 +156,38 @@ $side-navigation-z-index: 103;
       color: $colors--dark-theme--text-default;
       text-decoration: none;
     }
-  }
 
-  .p-panel__logo-name {
-    font-size: #{map-get($font-sizes, h4)}rem;
-    line-height: map-get($line-heights, x-small);
-    margin-bottom: 1.25rem !important;
-    padding-top: 0 !important;
-    margin-left: 2rem !important;
-    text-wrap: nowrap;
-    @media only screen and (min-width: ($breakpoint-small + 1)) {
-      margin-left: 2.5rem !important;
+    .p-panel__logo-text {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+
+      .p-panel__logo-name {
+        font-size: #{map-get($font-sizes, h4)}rem;
+        line-height: map-get($line-heights, x-small);
+        margin-bottom: 0;
+        padding-top: 0;
+        margin-left: 2rem;
+        text-wrap: nowrap;
+      }
+
+      .p-panel__logo-name--small {
+        font-size: 0.6rem;
+        margin-bottom: 0;
+        padding-left: 0.1rem;
+      }
     }
-  }
 
-  .p-navigation__tagged-logo {
-    min-width: auto;
-  }
+    .p-navigation__tagged-logo {
+      min-width: auto;
+    }
 
-  .p-navigation__tagged-logo .p-navigation__logo-tag {
-    height: 2.3rem;
-    left: 1rem;
-    @media only screen and (min-width: ($breakpoint-small + 1)) {
-      left: 1.5rem;
+    .p-navigation__tagged-logo .p-navigation__logo-tag {
+      height: 2.3rem;
+      left: 1rem;
+      @media only screen and (min-width: ($breakpoint-small + 1)) {
+        left: 1.5rem;
+      }
     }
   }
 }

--- a/src/lib/sections/Navigation/Navigation.stories.tsx
+++ b/src/lib/sections/Navigation/Navigation.stories.tsx
@@ -28,7 +28,10 @@ const meta: Meta<typeof Navigation> = {
                   <path d="M156.94 149H31.88a18.88 18.88 0 0 1 .27 19.5c-.09.16-.19.31-.29.46h125.08A6 6 0 0 0 163 163v-8.06a6 6 0 0 0-6-6Z" />
                 </Navigation.LogoIcon>
               </Navigation.LogoTag>
-              <Navigation.LogoName>MAAS</Navigation.LogoName>
+              <Navigation.LogoText>
+                <Navigation.LogoName variant="small">Canonical</Navigation.LogoName>
+                <Navigation.LogoName>MAAS</Navigation.LogoName>
+              </Navigation.LogoText>
             </Navigation.Logo>
           </Navigation.Banner>
           <Navigation.Controls>
@@ -60,7 +63,10 @@ const meta: Meta<typeof Navigation> = {
                     <path d="M156.94 149H31.88a18.88 18.88 0 0 1 .27 19.5c-.09.16-.19.31-.29.46h125.08A6 6 0 0 0 163 163v-8.06a6 6 0 0 0-6-6Z" />
                   </Navigation.LogoIcon>
                 </Navigation.LogoTag>
-                <Navigation.LogoName>MAAS</Navigation.LogoName>
+                <Navigation.LogoText>
+                  <Navigation.LogoName variant="small">Canonical</Navigation.LogoName>
+                  <Navigation.LogoName>MAAS</Navigation.LogoName>
+                </Navigation.LogoText>
               </Navigation.Logo>
               <Navigation.Controls>
                 <Navigation.CollapseToggle

--- a/src/lib/sections/Navigation/Navigation.tsx
+++ b/src/lib/sections/Navigation/Navigation.tsx
@@ -18,6 +18,7 @@ import { Logo } from "./Logo/Logo";
 import { LogoIcon } from "./LogoIcon/LogoIcon";
 import { LogoName } from "./LogoName/LogoName";
 import { LogoTag } from "./LogoTag/LogoTag";
+import { LogoText } from "./LogoText/LogoText";
 import { MenuButton } from "./MenuButton/MenuButton";
 import { Text } from "./Text/Text";
 
@@ -71,5 +72,6 @@ Navigation.Logo = Logo;
 Navigation.LogoTag = LogoTag;
 Navigation.LogoIcon = LogoIcon;
 Navigation.LogoName = LogoName;
+Navigation.LogoText = LogoText;
 
 NavigationBar.MenuButton = MenuButton;


### PR DESCRIPTION
## Done
- Added "small" variant to LogoName
- Created LogoText wrapper for LogoNames
- Created `p-panel__logo-text` class and styles
- Cleaned up CSS to remove the need for `!important`
- Decreased gap between name and logo tag to match UX designs

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Run storybook
- [ ] Ensure that "Canonical" can be seen in small text above "MAAS" in the navigation
- [ ] Set viewport size to small mobile
- [ ] Set isCollapsed to true
- [ ] Ensure the logo and text continues to be rendered properly

<!-- Steps for QA. -->

## Fixes

Fixes https://warthogs.atlassian.net/browse/MAASENG-2378

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/ndv99/maas-react-components/assets/35104482/e877b1b3-4d00-4490-8e89-1fddf4c703d7)

### After
![image](https://github.com/ndv99/maas-react-components/assets/35104482/686d81ff-ca36-4a0b-926f-1fc3a2a019f1)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->
